### PR TITLE
Add developer email to env vars

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,6 +50,7 @@ jobs:
         env:
           POE_CLIENT_ID: ${{ secrets.POE_CLIENT_ID }}
           POE_CLIENT_SECRET: ${{ secrets.POE_CLIENT_SECRET }}
+          DEVELOPER_EMAIL: mxmlnstock@gmail.com
         run: cargo test --all-features -- --nocapture --quiet
 
       - name: Format

--- a/configuration/environments/.env.template
+++ b/configuration/environments/.env.template
@@ -2,6 +2,7 @@
 ENV=development
 RUST_LOG=info,ureq=warn,sqlx=warn
 METRICS_PORT=4000
+DEVELOPER_EMAIL=
 
 # Reverse Proxy
 HOST=localhost

--- a/crates/stash-api/src/common/poe_api.rs
+++ b/crates/stash-api/src/common/poe_api.rs
@@ -3,7 +3,8 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 
 pub fn user_agent(client_id: &str) -> String {
-    format!("OAuth {client_id}/0.1 (contact: mxmlnstock@gmail.com)")
+    let developer_email = std::env::var("DEVELOPER_EMAIL").expect("Missing enviroment variable DEVELOPER_EMAIL");
+    format!("OAuth {client_id}/0.1 (contact: {developer_email})")
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/stash-api/src/sync/fetcher.rs
+++ b/crates/stash-api/src/sync/fetcher.rs
@@ -35,7 +35,7 @@ impl FetchTask {
 
     pub(crate) fn retry(self) -> Option<Self> {
         Some(FetchTask { ..self })
-    }đ
+    }
 }
 
 #[derive(Debug)]

--- a/crates/stash-api/src/sync/fetcher.rs
+++ b/crates/stash-api/src/sync/fetcher.rs
@@ -63,7 +63,6 @@ pub(crate) fn start_fetcher(
     scheduler_tx: Sender<SchedulerMessage>,
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
-        // Should this be prefixed with POE_ or is unused currently?
         let client_id = std::env::var("CLIENT_ID").unwrap();
         let client_secret = std::env::var("CLIENT_SECRET").unwrap();
 

--- a/crates/stash-api/src/sync/fetcher.rs
+++ b/crates/stash-api/src/sync/fetcher.rs
@@ -35,7 +35,7 @@ impl FetchTask {
 
     pub(crate) fn retry(self) -> Option<Self> {
         Some(FetchTask { ..self })
-    }
+    }đ
 }
 
 #[derive(Debug)]
@@ -63,6 +63,7 @@ pub(crate) fn start_fetcher(
     scheduler_tx: Sender<SchedulerMessage>,
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
+        // Should this be prefixed with POE_ or is unused currently?
         let client_id = std::env::var("CLIENT_ID").unwrap();
         let client_secret = std::env::var("CLIENT_SECRET").unwrap();
 


### PR DESCRIPTION
I have added developer email to the env variables so when getting the access token the "correct" email will be used in the user agent. 